### PR TITLE
feat: record createdBy/lastEditedBy on expenses

### DIFF
--- a/api/expenses/create.ts
+++ b/api/expenses/create.ts
@@ -1,5 +1,6 @@
 import { app, HttpRequest, HttpResponseInit, InvocationContext } from '@azure/functions'
 import { getTableClient, getTripIdBySlug, listTripRows, newId, nowIso } from '../shared/tableClient'
+import { getClientPrincipal, getAuthenticatedUser, isAuthenticated } from '../shared/auth'
 
 interface CreateExpenseBody {
   amount: number
@@ -40,6 +41,10 @@ app.http('createExpense', {
         return { status: 423, jsonBody: { error: 'trip locked' } }
       }
   // Public mode: no auth required
+      const principal = getClientPrincipal(req)
+      const user = isAuthenticated(principal) ? getAuthenticatedUser(principal) : null
+      const createdBy = user ? user.name : null
+
       const participantIds = new Set(rows.filter(r => r.type === 'participant').map(r => r.participantId))
       if (!participantIds.has(body.paidBy)) return { status: 400, jsonBody: { error: 'paidBy participant not found' } }
       for (const pid of body.participants) { if (!participantIds.has(pid)) return { status: 400, jsonBody: { error: `participant not found: ${pid}` } } }
@@ -57,7 +62,9 @@ app.http('createExpense', {
         paidBy: body.paidBy,
         participantIds: body.participants.join(','),
         createdAt: now,
-        updatedAt: now
+        updatedAt: now,
+        createdBy: createdBy || '',
+        lastEditedBy: ''
       })
       return { status: 201, jsonBody: {
         id: expenseId,
@@ -67,7 +74,9 @@ app.http('createExpense', {
         description: body.description || '',
         paidBy: body.paidBy,
         participants: body.participants,
-        createdAt: now
+        createdAt: now,
+        createdBy,
+        lastEditedBy: null
       }}
     } catch (e: any) {
       ctx.error(e)

--- a/api/expenses/update.ts
+++ b/api/expenses/update.ts
@@ -1,5 +1,6 @@
 import { app, HttpRequest, HttpResponseInit, InvocationContext } from '@azure/functions'
 import { getTableClient, getTripIdBySlug, listTripRows, nowIso } from '../shared/tableClient'
+import { getClientPrincipal, getAuthenticatedUser, isAuthenticated } from '../shared/auth'
 
 interface UpdateExpenseBody {
   amount?: number
@@ -40,6 +41,10 @@ app.http('updateExpense', {
         return { status: 423, jsonBody: { error: 'trip locked' } }
       }
   // Public mode: no auth required
+      const principal = getClientPrincipal(req)
+      const user = isAuthenticated(principal) ? getAuthenticatedUser(principal) : null
+      const lastEditedBy = user ? user.name : null
+
       const expense: any = rows.find(r => r.rowKey === `expense:${expenseId}`)
       if (!expense) return { status: 404, jsonBody: { error: 'expense not found' } }
       const participantIds = new Set(rows.filter(r => r.type === 'participant').map(r => r.participantId))
@@ -55,7 +60,8 @@ app.http('updateExpense', {
         description: body.description !== undefined ? body.description : expense.description,
         paidBy: body.paidBy || expense.paidBy,
         participantIds: body.participants ? body.participants.join(',') : expense.participantIds,
-        updatedAt: nowIso()
+        updatedAt: nowIso(),
+        lastEditedBy: lastEditedBy || ''
       }
       await client.updateEntity(updated, 'Replace')
       return { status: 200, jsonBody: {
@@ -67,7 +73,9 @@ app.http('updateExpense', {
         paidBy: updated.paidBy,
         participants: updated.participantIds.split(',').filter(Boolean),
         createdAt: updated.createdAt,
-        updatedAt: updated.updatedAt
+        updatedAt: updated.updatedAt,
+        createdBy: updated.createdBy || null,
+        lastEditedBy
       }}
     } catch (e: any) {
       ctx.error(e)

--- a/api/shared/tableClient.ts
+++ b/api/shared/tableClient.ts
@@ -54,6 +54,8 @@ export interface ExpenseRow {
   participantIds: string
   createdAt: string
   updatedAt: string
+  createdBy?: string
+  lastEditedBy?: string
 }
 
 export interface SlugIndexRow {

--- a/api/trip/getBySlug.ts
+++ b/api/trip/getBySlug.ts
@@ -43,7 +43,9 @@ app.http('getTripBySlug', {
         paidBy: r.paidBy,
         participants: (r.participantIds || '').split(',').filter(Boolean),
         createdAt: r.createdAt,
-        updatedAt: r.updatedAt
+        updatedAt: r.updatedAt,
+        createdBy: (r as any).createdBy || null,
+        lastEditedBy: (r as any).lastEditedBy || null
       }))
 
       const contributors = rows.filter(r => r.type === 'contributor').map(r => ({

--- a/packages/shared-types/index.ts
+++ b/packages/shared-types/index.ts
@@ -24,6 +24,8 @@ export interface Expense {
   paidBy: string
   participants: string[]
   createdAt: string
+  createdBy?: string | null
+  lastEditedBy?: string | null
 }
 
 export interface Contributor {


### PR DESCRIPTION
When a signed-in user creates or edits an expense, store their display name in createdBy and lastEditedBy fields. Anonymous users still get null. Fields are returned in API responses and persisted in Azure Table Storage.